### PR TITLE
Updates

### DIFF
--- a/source/macosoverview.adoc
+++ b/source/macosoverview.adoc
@@ -22,12 +22,12 @@ There are instructions below for both choices. If I was you, I would use the Gre
 
  . Double click the Great Cow BASIC icon and follow the installer prompts.
 
-Instructions for building your own Great Cow BASIC binary
+*Instructions for building your own Great Cow BASIC binary*
 
 Complete the following steps to compile and install Great Cow BASIC:
 
 [start=1]
- . Download the FreeBASIC 1.06 macOS 10.4 binary compilation from: http://tmc.castleparadox.com/temp/fbc-1.06-darwin-wip20160505.tar.bz2
+ . Download the FreeBASIC 1.06 macOS binary compilation from: http://tmc.castleparadox.com/temp/fbc-1.06-darwin-wip20160505.tar.bz2
 
  . Download the Great Cow BASIC macOS Source Distribution from SourceForge at https://sourceforge.net/projects/gcbasic/files/GCB-macOS-src.tar.bz2/download
 
@@ -116,10 +116,13 @@ Now you should be able create GCB source files with your favourite editor and co
 
 To program your microcontroller with your Great Cow BASIC-created hex file, you will need additional hardware and software.
 
-. For Microchip PIC microcontroller programming, you might find what you need at: http://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=pg164120 and the macOS version of the pk2cmd v1.2 command line programming software.
+. For Microchip PIC microcontroller programming, you might find what you need at: https://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=pg164120 and the macOS version of the `pk2cmd` v1.2 command line programming software.
 
-. For Atmel AVR microcontroller programming, you will need the avrdude programming software. Check here: http://www.nongnu.org/avrdude/ for it.
+. For Atmel AVR microcontroller programming, you will need the `avrdude` programming software. Check here: http://www.nongnu.org/avrdude/ for it.
 
+Alternatively, if you use Virtual Machine software such as _Parallels_ or _VMWare Fusion_ to run Windows programs, you can use Windows GUI programming software.
+
+* For Microchip, the PICKit 2 and PICkit 3 standalone GUI software or even better the PICkitPlus software (https://sourceforge.net/projects/pickit3plus/) for both the PICkit 2 (https://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=pg164120) and PICkit 3 (https://www.microchip.com/Developmenttools/ProductDetails/PG164130) which has fixed various bugs in those programs and been updated to program the latest Microchip 8 bit microcontrollers.
 
 *Help*
 

--- a/source/macosoverview.adoc
+++ b/source/macosoverview.adoc
@@ -2,7 +2,7 @@
 
 *Introduction*
 
-Great Cow BASIC can be used with the Apple macOS operatimg system.
+Great Cow BASIC can be used with the Apple macOS operating system.
 
 These instructions are for Apple macOS only (not Windows).
 
@@ -41,7 +41,7 @@ Complete the following steps to compile and install Great Cow BASIC:
 ----
 
 [start=6]
- . Unpack the gcc-8.1.tar.bz2 compressed tar file by typing the following comamnd into your Terminal window:
+ . Unpack the gcc-8.1.tar.bz2 compressed tar file by typing the following command into your Terminal window:
 ----
    gzcat gcc-8.1.tar.bz2 | tar xvf -
 ----
@@ -112,16 +112,16 @@ Note 2: You may need to alter the library and include paths in the build.sh scri
 
 Now you should be able create GCB source files with your favourite editor and compile those files with the gcbasic compiler.
 
-Programming microcontrollers
+*Programming microcontrollers*
 
 To program your microcontroller with your Great Cow BASIC-created hex file, you will need additional hardware and software.
 
-. For Microchip PIC microcontroller programming, you might find what you need at: http://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=pg164120 and the programming software pk2cmd v1.2.
+. For Microchip PIC microcontroller programming, you might find what you need at: http://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=pg164120 and the macOS version of the pk2cmd v1.2 command line programming software.
 
 . For Atmel AVR microcontroller programming, you will need the avrdude programming software. Check here: http://www.nongnu.org/avrdude/ for it.
 
 
-Help
+*Help*
 
 Great Cow BASIC Help documentation is installed in the Documentation subdirectory in your GreatCowBasic directory.
 

--- a/source/maintenance.adoc
+++ b/source/maintenance.adoc
@@ -1,15 +1,14 @@
 === Great Cow BASIC Maintenance
 
 *Introduction:*
-Great Cow BASIC maintenance covers the key processess that the developers use to maintain and build the solution.
+Great Cow BASIC maintenance covers the key processes that the developers use to maintain and build the solution.
 
-This insights are not distribution specific
+These insights are not distribution specific.
 
 *Solution Architecture:*
-Complete the components are key for a complete solution:
+These components are key for a complete solution:
 [start=1]
  . Great Cow BASIC installer
-
 
  . Great Cow BASIC chip specific .DAT files
 
@@ -20,12 +19,14 @@ Complete the components are key for a complete solution:
 
 {empty} +
 {empty} +
-*Great Cow BASIC installer:*
+*Great Cow BASIC installers:*
 {empty} +
 {empty} +
-The Great Cow BASIC installer used the InnoSoft installer with packaging completed using R2Build. +
+The Windows Great Cow BASIC installer uses the _InnoSoft_ installer with packaging completed using R2Build. +
 
-The process uses a Gold build structure.  The R2Build software creates four packages for Windows and one package for the Linus distribution.  The process is automated with automatic versioning and configuration.
+The process uses a Gold build structure.  The R2Build software creates four packages for Windows and one package for the Linux distribution.  The process is automated with automatic versioning and configuration.
+
+The macOS Great Cow BASIC installer uses the _Packages_ installer (http://s.sudre.free.fr/Software/Packages/about.html) with packaging completed using the Bourne shell script `pkg2dmg.sh` to create a compressed disk image file containing the installer.
 
 {empty} +
 {empty} +
@@ -34,11 +35,11 @@ The process uses a Gold build structure.  The R2Build software creates four pack
 {empty} +
 What are the .DAT files?
 
-The DAT files are the Great Cow BASIC respresentation of capabilities of a specific microcontroller.&#160;&#160;The DAT is based upon a number of vendor sources and corrections/ommissions added by the Great Cow BASIC development team.&#160;&#160;The DAT file is exposed to the user program as a set of registers and register bits that can used to configure the program in terms of the microcontroller specifics.
+The DAT files are the Great Cow BASIC representation of the capabilities of a specific microcontroller.&#160;&#160;The DAT is based upon a number of vendor sources and corrections/omissions added by the Great Cow BASIC development team.&#160;&#160;The DAT file is exposed to the user program as a set of registers and register bits that can used to configure the program in terms of the microcontroller specifics.
 {empty} +
 {empty} +
 
-The process to create the .DAT file for chips is as follows:
+The process to create the .DAT file for microcontrollers is as follows:
 [cols="2", options="header,autowidth"]
 |===
 |Step
@@ -49,9 +50,9 @@ The process to create the .DAT file for chips is as follows:
 |2
 |For Microchip only.  Place the source INC files in the ..DAT\incfiles\OrgFiles.
 
-Process the file using 'Preprocess.bat'. &#160;&#160; This is an AWK text processor - you will required AWK.EXE in the executing folder.
+Process the file using 'Preprocess.bat'. &#160;&#160; This is an AWK text processor - you will need AWK.EXE in the executing folder.
 
-This preprocessing will examine all the INC files in the ..DAT\incfiles\OrgFiles folder.&#160;&#160;The resulting files will be placed in the ..DAT\incfiles folder.&#160;&#160;The resulting files will have the 'BITS' section sorted in port priority - this priority ensures the bits are assigned in the target DAT in the same order everytime.
+This preprocessing will examine all the INC files in the ..DAT\incfiles\OrgFiles folder.&#160;&#160;The resulting files will be placed in the ..DAT\incfiles folder.&#160;&#160;The resulting files will have the 'BITS' section sorted in port priority - this priority ensures the bits are assigned in the target DAT in the same order every time.
 
 |3
 |Update the database of support microcontrollers.&#160;&#160;This database contains the microcontroller configuration that Great Cow BASIC requires as the core information for the DAT files.
@@ -59,16 +60,16 @@ This preprocessing will examine all the INC files in the ..DAT\incfiles\OrgFiles
 The database is called `chipdata.csv` or `avr_chipdata.csv` for Microchip and AVR respectively.
 - These files are comma delimited.&#160;&#160;The first row of data specifies the field name - these field names control the chip conversion program, see later notes.&#160;&#160;
 
-The database fields are controlled by the Great Cow BASIC development team and the specification of the database may change between release to support new capabilities.
+The database fields are controlled by the Great Cow BASIC development team and the specification of the database may change between releases to support new capabilities.
 
-Database fields will the suffix of `Variant` such as PWMTimerVariant and SMTClockSourceVariant are microcontroller specific configuration settings to support the various microcontroller settings.&#160;&#160;These values of these `variants` is determined by the examination of the microcontrollers datasheet as this information is NOT specified in the source files.&#160;&#160;Variants are exposed in the user program with the prefix of Chip.&#160;&#160;If the variant is called `PWMTimerVariant` a constant caled `ChipPWMTimerVariant` will be exposed in the user program.
+Database fields will have the suffix of `Variant` such as PWMTimerVariant and SMTClockSourceVariant and are microcontroller specific configuration settings to support the various microcontroller settings.&#160;&#160;The values of these `variants` are determined by the examination of the microcontroller datasheets as this information is NOT specified in the source files.&#160;&#160;Variants are exposed in the user program with the prefix of Chip.&#160;&#160;If the variant is called `PWMTimerVariant` a constant called `ChipPWMTimerVariant` will be exposed in the user program.
 
 |4
-|Update the `CriticalChanges.txt` file, if required.&#160;&#160;The `CriticalChanges.txt` file contains changes the INC file during processing that are corrections or additions to the source files.
+|Update the `CriticalChanges.txt` file, if required.&#160;&#160;The `CriticalChanges.txt` file contains changes to the INC file during processing that are corrections or additions to the source files.
 
 The format of each line is the `filename` , `Append (new line) or Replace`, `find`, `replace`.
 
-Each line is comma delimited  and spaces are NOT critical.  &#160;&#160;Essentially, the processing with find a partial line and replace or append the whole line.
+Each line is comma delimited and spaces are NOT critical.  &#160;&#160;Essentially, the processing with find a partial line and replace or append the whole line.
 
 example:  p16lf1615.inc,R,OSCFIE          EQU  H'0007',OSFIE           EQU  H'0007'&#160;&#160;&#160;&#160;
 - so, when processing p16lf1615.inc find the line OSCFIE          EQU  H'0007' and replace with OSFIE           EQU  H'0007'.
@@ -80,7 +81,7 @@ example:  p16lf1615.inc,R,OSCFIE          EQU  H'0007',OSFIE           EQU  H'00
 |6
 |Maintain the conversion program.&#160;&#160;The conversion program may require maintenance. &#160;&#160;The programs are written in FreeBASIC and therefore require compilation.
 
-Examples of maintenance is-  a new variant field is required.&#160;&#160;The source program will need to be update to support the new variant - simply edit the source, compile and publish.&#160;&#160;Another example is the addition of new Interrupt - follow the same process to edit, compile and publish.
+An example of maintenance is a new variant field is required.&#160;&#160;The source program will need to be updated to support the new variant - simply edit the source, compile and publish.&#160;&#160;Another example is the addition of a new Interrupt - follow the same process to edit, compile and publish.
 
 
 |7
@@ -88,17 +89,17 @@ Examples of maintenance is-  a new variant field is required.&#160;&#160;The sou
 
 Executing the conversion program without a parameter will process ALL the entries in the database (the csv file), passing a single parameter to the conversion program will only convert the single microcontroller.
 
-The conversion program will process as follow:
+The conversion program will process as follows:
 
 a) Read the database for the chip specifics
 
-b) If a .DEV file or .INFO file is not present a routine called GuessDefaultConfig.  This method sets the bit(s).
+b) If a .DEV file or .INFO file is not present a routine called GuessDefaultConfig is invoked.  This method sets the bit(s).
 
 In all cases the default mask is sometimes specified for a particular config option and that is used for ASMConfig
 
 See the section below for the processing of a .DEV file.
 
-c) For all microcontrollers read the `CriticalChanges.txt` and process.
+c) For all microcontrollers read the `CriticalChanges.txt` file and process.
 
 d) For 18f microcontrollers read the `18FDefaultASMConfig.txt`.  This simply overwrites all options stated in 18FDefaultASMConfig.TXT  and marks this in the output DAT file.
 
@@ -127,8 +128,8 @@ Where the default is selected from the Info_Type.
 
 
 
-**Prog = .  An explaination of the parameter**.
-The Prog value is measured in words. It is the same one devices in the device specific.dat files.
+**Prog = .  An explanation of the parameter**.
+The Prog value is measured in words. It is the same in the device specific.dat files.
 {empty} +
 
 Microchip in the past have used words, but then they started using bytes on the website instead to make their chips appear to have larger capacity.


### PR DESCRIPTION
Update of macosoverview.adoc - fixed typos; added PICkitPlus :)

Update of maintenance.adoc - fixed typos; added macOS installer description.

I used italics in a  few places - just a warning in case your build system does not cope.