### PR TITLE
Fix build.sh scripts being unexecutable by using 'sh build.sh'

### DIFF
--- a/source/freebsdoverview.adoc
+++ b/source/freebsdoverview.adoc
@@ -33,7 +33,7 @@ This will produce a new directory called GreatCowBasic. *Note:* If you do not al
 . Execute the FreeBSDBuild/build.sh shell script from the Sources directory.
 
 ----
-  ../FreeBSDBuild/install.sh [all | build | install]
+  sh FreeBSDBuild/install.sh [all | build | install]
 ----
 
 The build script arguments are:

--- a/source/macosoverview.adoc
+++ b/source/macosoverview.adoc
@@ -98,7 +98,7 @@ This will produce a new directory called GreatCowBasic. *Note:* If you do not cu
 [start=15]
 . Compile the Great Cow BASIC binary (gcbasic) by typing the following command into your Terminal window:
 ----
-  DarwinBuild/build.sh
+  sh DarwinBuild/build.sh
 ----
 Note 1: If you did not install the various files with the same names as in the instructions above into your Home directory, you will need to edit the build.sh script file and change the file paths and filenames to the appropriate values.
 


### PR DESCRIPTION
As the install.sh scripts do not have the x bit set, rather than telling users to chmod them, preface them with the Bourne shell interpreter to execute them instead.